### PR TITLE
Add explicit parentheses for ternary operator

### DIFF
--- a/classes/Completeness.php
+++ b/classes/Completeness.php
@@ -80,9 +80,10 @@ class Completeness extends BaseTab {
       usort($this->packages, function($a, $b){
         return ($a->packageid == $b->packageid)
          ? 0
-         : ($a->packageid < $b->packageid)
+         : (($a->packageid < $b->packageid)
             ? -1
-            : 1;
+            : 1
+           );
       });
     } else {
       $msg = sprintf("file %s is not existing", $elementsFile);


### PR DESCRIPTION
Per https://wiki.php.net/rfc/ternary_associativity

Note: By adding parentheses around the second part, I'm changing the behaviour of the code, but from looking at the code, I assume that you intended the operator to actually be right-associative here? 
