### PR TITLE
Introduce PHP composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ images/
 libs/
 cache/
 translate.sh
+vendor/
+_smarty/
 
 # eidtor files
 .idea/

--- a/README.md
+++ b/README.md
@@ -47,8 +47,15 @@ prepare configuration file:
 ```
 cd /var/www/html/[catalogue]
 ```
- You can also add the [catalogue] infor the configuration if the 
- application path does not equals to the [catalogue]:
+
+You can also add the [catalogue] infor the configuration if the 
+application path does not equals to the [catalogue]:
+
+install PHP dependencies and create required cache directories and permissions:
+
+```
+composer install
+```
 
 prepare configuration file:
 ```
@@ -76,27 +83,11 @@ indexName[bvb]=bayern
 dirName[bvb]=bayern
 ```
 
-setup directories and permissions, download the Smarty templating library.
+setup additional directories and permissions:
 
 ```
-mkdir cache
-touch selected-facets.js
 sudo chown www-data:www-data -R cache
-chmod g+w -R cache
-mkdir libs
-mkdir images
-
 ln -s [data directory]/[catalogue]/img images/[catalogue]
-
-# download Smarty templating library
-export SMARTY_VERSION=3.1.44
-cd libs/
-curl -s -L https://github.com/smarty-php/smarty/archive/v${SMARTY_VERSION}.zip --output v$SMARTY_VERSION.zip
-unzip -q v${SMARTY_VERSION}.zip
-rm v${SMARTY_VERSION}.zip
-mkdir -p _smarty/templates_c
-chmod a+w -R _smarty/templates_c/
-cd ..
 ```
 
 Add these lines to Apache configuration (`/etc/apache2/sites-available/000-default.conf`)

--- a/README.md
+++ b/README.md
@@ -144,11 +144,10 @@ msgid "by document types"
 msgstr "nach Dokumenttypen"
 ```
 
-Once you have done, you should generate the `.mo` files from the `.po` files with the following commands:
+Once you have done, you should generate the `.mo` files from the `.po` files with the following command:
 
 ```bash
-msgfmt locale/de_DE/LC_MESSAGES/messages.po -o locale/de_DE/LC_MESSAGES/messages.mo
-msgfmt locale/en_GB/LC_MESSAGES/messages.po -o locale/en_GB/LC_MESSAGES/messages.mo
+composer run translate
 ```
 
 Please let me know if you would like to see more languages supported.

--- a/common-functions.php
+++ b/common-functions.php
@@ -32,9 +32,7 @@ function getPath() {
 
 function createSmarty($templateDir) {
   define('APPLICATION_DIR', __DIR__);
-  define('SMARTY_DIR', APPLICATION_DIR . '/libs/smarty-3.1.44/libs/');
-  define('_SMARTY', APPLICATION_DIR . '/libs/_smarty/');
-  require_once(SMARTY_DIR . 'Smarty.class.php');
+  define('_SMARTY', APPLICATION_DIR . '/_smarty/');
   $smarty = new Smarty();
   $smarty->setTemplateDir(getcwd() . '/' . $templateDir);
   $smarty->setCompileDir(_SMARTY . '/templates_c/');

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "pkiraly/metadata-qa-marc-web",
+  "scripts": {
+    "post-install-cmd": [
+      "mkdir -p cache libs images _smarty/templates_c _smarty/cache",
+      "touch cache/selected-facets.js",
+      "chmod g+w -R _smarty cache"
+    ]
+  },
+  "require": {
+    "smarty/smarty": "^3.1"
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,7 @@
 {
   "name": "pkiraly/metadata-qa-marc-web",
+  "type": "project",
+  "license": "GPL-3.0-or-later",
   "scripts": {
     "post-install-cmd": [
       "mkdir -p cache libs images _smarty/templates_c _smarty/cache",
@@ -11,6 +13,12 @@
       "msgfmt locale/en_GB/LC_MESSAGES/messages.po -o locale/en_GB/LC_MESSAGES/messages.mo"
     ]
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/pkiraly/metadata-qa-marc-web"
+    }
+  ],
   "require": {
     "smarty/smarty": "^3.1"
   }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,10 @@
       "mkdir -p cache libs images _smarty/templates_c _smarty/cache",
       "touch cache/selected-facets.js",
       "chmod g+w -R _smarty cache"
+    ],
+    "translate": [
+      "msgfmt locale/de_DE/LC_MESSAGES/messages.po -o locale/de_DE/LC_MESSAGES/messages.mo",
+      "msgfmt locale/en_GB/LC_MESSAGES/messages.po -o locale/en_GB/LC_MESSAGES/messages.mo"
     ]
   },
   "require": {

--- a/index.php
+++ b/index.php
@@ -1,6 +1,8 @@
 <?php
 set_time_limit(0);
 
+require 'vendor/autoload.php';
+
 require_once 'common-functions.php';
 $marcBaseUrl = 'https://www.loc.gov/marc/bibliographic/';
 $configuration = parse_ini_file("configuration.cnf", false, INI_SCANNER_TYPED);


### PR DESCRIPTION
Installation of dependencies such as Smarty and initial setup is facilitated by using PHP composer. The file `composer.json` is also be useful to add project metadata such as version number and for unit tests.